### PR TITLE
fix: harden auto-mode safety + scan loop reliability

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-22T11:35:04.600Z for PR creation at branch issue-3-05c26e67cc55 for issue https://github.com/maksmoroz91/poly/issues/3

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-22T11:35:04.600Z for PR creation at branch issue-3-05c26e67cc55 for issue https://github.com/maksmoroz91/poly/issues/3

--- a/README.md
+++ b/README.md
@@ -79,21 +79,36 @@ Uses Node's built-in test runner — no test dependencies to install.
 src/
   config.js            env/.env parsing + validation
   logger.js            timestamped console logger
+  retry.js             exponential backoff + jitter helper for HTTP calls
+  ttl-cache.js         bounded TTL cache for signal dedupe
   polymarket/
-    client.js          Gamma API fetch + market normalization
+    client.js          Gamma + CLOB API client (paginated, retried)
   scanner.js           filters + arb math
   categorize.js        esports / politics / crypto classifier
-  telegram.js          Bot API notifier + signal formatter
-  executor.js          parallel YES+NO buyer with rollback
+  telegram.js          Bot API notifier with retry + async send queue
+  executor.js          parallel YES+NO buyer; real-ask re-check + naked-leg alert
   index.js             main loop
 test/                  unit tests for every module above
 ```
 
 ## Safety
 
-- The arbitrage math assumes both legs fill at the quoted ask. In auto mode
-  the executor should re-check the real top-of-book just before firing; the
-  injected `placeOrder` hook is the right place to add that.
-- Rollback is best-effort: if one leg fills and the cancel of the other
-  fails, the operator must reconcile manually.
+- In auto mode the executor pulls the real top-of-book ask from the CLOB
+  (`/book?token_id=...`) and re-validates the arb (sum + size) before placing
+  any order. If the real spread no longer clears `MIN_PROFIT_PERCENT` the
+  trade is aborted with an `aborted: real_ask_too_high` result and no orders
+  are placed.
+- Rollback distinguishes two failure modes: a benign network miss is logged,
+  but an `already_filled` cancel response triggers a critical Telegram alert
+  (`🚨 naked leg`) so the operator can reconcile the open position immediately.
+- The Gamma client paginates through `/markets` until the API returns a short
+  page, so no active markets are silently skipped past the first 500.
+- Gamma and Telegram requests retry with exponential backoff + jitter on 429,
+  5xx and transient network errors so a brief outage doesn't drop signals.
+- Telegram dispatch is queued — `enqueue()` returns immediately, so a slow
+  or unreachable Telegram API can never block the scan loop.
+- Signal dedupe uses a 1-hour TTL cache, so a market that briefly disappears
+  from a paginated API response is re-emitted once it reappears with a fresh
+  arb window (instead of being muted until 10 000 distinct markets have been
+  seen).
 - Start with `BOT_MODE=monitor` until you trust the signal quality.

--- a/src/executor.js
+++ b/src/executor.js
@@ -6,27 +6,66 @@
 // the bot can run in `monitor` mode without any chain libraries installed,
 // and unit tests can exercise the rollback logic with an in-memory fake.
 
+// Cancel-failure reasons that mean a leg actually executed and the operator
+// is now naked on one side. These need a separate, louder alert path than
+// generic network errors.
+const ALREADY_FILLED_PATTERNS = [
+  /already[\s_-]*filled/i,
+  /already[\s_-]*matched/i,
+  /already[\s_-]*executed/i,
+  /not[\s_-]*cancellable/i,
+  /cannot[\s_-]*cancel/i,
+  /order[\s_-]*(is[\s_-]*)?(complete|completed|done)/i,
+];
+
+function isAlreadyFilledError(err) {
+  if (!err) return false;
+  if (err.alreadyFilled === true) return true;
+  if (typeof err.code === 'string' && /filled|matched/i.test(err.code)) return true;
+  const msg = err.message || String(err);
+  return ALREADY_FILLED_PATTERNS.some((re) => re.test(msg));
+}
+
 export class ParallelExecutor {
   /**
    * @param {object} opts
    * @param {(args: {tokenId: string, size: number, price: number, side: 'BUY'|'SELL'}) => Promise<{id: string}>} opts.placeOrder
    * @param {(orderId: string) => Promise<void>} opts.cancelOrder
+   * @param {(tokenId: string) => Promise<{bestAsk: {price:number,size:number}|null}>} [opts.fetchOrderBook]
+   *   Called in auto mode to verify the real top-of-book ask before firing.
+   * @param {number} [opts.feePercent]   Fee % used in the threshold check.
+   * @param {number} [opts.minProfitPercent] Minimum profit % required after re-check.
+   * @param {(alert: {kind: string, message: string, context?: object}) => void} [opts.onCriticalAlert]
+   *   Invoked when a leg appears to be filled but cancellation failed (manual reconciliation needed).
    * @param {object} [opts.logger]
    */
-  constructor({ placeOrder, cancelOrder, logger = console }) {
+  constructor({
+    placeOrder,
+    cancelOrder,
+    fetchOrderBook,
+    feePercent = 0,
+    minProfitPercent = 0,
+    onCriticalAlert,
+    logger = console,
+  }) {
     if (typeof placeOrder !== 'function' || typeof cancelOrder !== 'function') {
       throw new Error('ParallelExecutor requires placeOrder and cancelOrder functions');
     }
     this.placeOrder = placeOrder;
     this.cancelOrder = cancelOrder;
+    this.fetchOrderBook = fetchOrderBook;
+    this.feePercent = feePercent;
+    this.minProfitPercent = minProfitPercent;
+    this.onCriticalAlert = onCriticalAlert;
     this.logger = logger;
   }
 
   /**
    * Buy YES and NO of the same market in parallel, for an equal notional
    * capped at maxBetUsdc. If either order fails we attempt to cancel the
-   * other; any cancellation error is logged but not rethrown so the caller
-   * still sees the original failure.
+   * other; cancellation failures are classified as either a benign network
+   * miss or — critically — an already-filled order that needs operator
+   * intervention.
    */
   async executeArbitrage({ market, maxBetUsdc }) {
     const yes = market.yes;
@@ -35,7 +74,20 @@ export class ParallelExecutor {
       throw new Error('Market is missing CLOB token ids for YES/NO');
     }
 
-    const sum = yes.price + no.price;
+    let yesPrice = yes.price;
+    let noPrice = no.price;
+
+    // Fix #1 from issue: outcomePrices is a mid/last quote on Gamma. Before
+    // committing capital we pull the real top-of-book ask from the CLOB and
+    // re-validate the arb. If the real spread is gone we abort cleanly.
+    if (this.fetchOrderBook) {
+      const recheck = await this.recheckTopOfBook({ yes, no, maxBetUsdc });
+      if (!recheck.ok) return recheck;
+      yesPrice = recheck.yesAsk;
+      noPrice = recheck.noAsk;
+    }
+
+    const sum = yesPrice + noPrice;
     if (!(sum > 0 && sum < 1)) {
       throw new Error(`Arbitrage preconditions not met; sum=${sum}`);
     }
@@ -47,8 +99,8 @@ export class ParallelExecutor {
     const noSize = pairs;
 
     const results = await Promise.allSettled([
-      this.placeOrder({ tokenId: yes.tokenId, size: yesSize, price: yes.price, side: 'BUY' }),
-      this.placeOrder({ tokenId: no.tokenId, size: noSize, price: no.price, side: 'BUY' }),
+      this.placeOrder({ tokenId: yes.tokenId, size: yesSize, price: yesPrice, side: 'BUY' }),
+      this.placeOrder({ tokenId: no.tokenId, size: noSize, price: noPrice, side: 'BUY' }),
     ]);
 
     const [yesRes, noRes] = results;
@@ -59,35 +111,99 @@ export class ParallelExecutor {
         yesOrderId: yesRes.value.id,
         noOrderId: noRes.value.id,
         pairs,
+        yesPrice,
+        noPrice,
       };
     }
 
     // One leg failed — roll back the other so we don't end up naked on a side.
     const rollback = [];
     if (yesRes.status === 'fulfilled') {
-      rollback.push(
-        this.safeCancel(yesRes.value.id, 'YES'),
-      );
+      rollback.push(this.safeCancel(yesRes.value.id, 'YES', { market }));
     }
     if (noRes.status === 'fulfilled') {
-      rollback.push(
-        this.safeCancel(noRes.value.id, 'NO'),
-      );
+      rollback.push(this.safeCancel(noRes.value.id, 'NO', { market }));
     }
-    await Promise.all(rollback);
+    const rollbackResults = await Promise.all(rollback);
+    const naked = rollbackResults.filter((r) => r.alreadyFilled);
 
     const errors = results
       .filter((r) => r.status === 'rejected')
       .map((r) => r.reason?.message || String(r.reason));
-    return { ok: false, errors };
+
+    return { ok: false, errors, naked };
   }
 
-  async safeCancel(orderId, label) {
+  async recheckTopOfBook({ yes, no, maxBetUsdc }) {
+    const [yesBook, noBook] = await Promise.all([
+      this.fetchOrderBook(yes.tokenId),
+      this.fetchOrderBook(no.tokenId),
+    ]);
+    const yesAskLevel = yesBook?.bestAsk;
+    const noAskLevel = noBook?.bestAsk;
+    if (!yesAskLevel || !noAskLevel) {
+      return { ok: false, errors: ['real top-of-book ask unavailable'], aborted: 'no_ask' };
+    }
+    const yesAsk = yesAskLevel.price;
+    const noAsk = noAskLevel.price;
+    const sum = yesAsk + noAsk;
+    const fee = this.feePercent / 100;
+    const profitPercent = sum > 0 ? ((1 - fee - sum) / sum) * 100 : -100;
+    if (profitPercent < this.minProfitPercent) {
+      this.logger.warn?.(
+        `[executor] real-ask re-check killed arb: yesAsk=${yesAsk} noAsk=${noAsk} sum=${sum.toFixed(4)} profit%=${profitPercent.toFixed(2)} (min ${this.minProfitPercent})`,
+      );
+      return {
+        ok: false,
+        aborted: 'real_ask_too_high',
+        yesAsk,
+        noAsk,
+        sum,
+        profitPercent,
+        errors: [`real ask sum ${sum.toFixed(4)} fails minProfitPercent ${this.minProfitPercent}`],
+      };
+    }
+    // Make sure the book has enough size to fill what we want to spend.
+    const pairs = maxBetUsdc / sum;
+    if (yesAskLevel.size < pairs || noAskLevel.size < pairs) {
+      this.logger.warn?.(
+        `[executor] insufficient ask size: need ${pairs.toFixed(2)} pairs, yes=${yesAskLevel.size} no=${noAskLevel.size}`,
+      );
+      return {
+        ok: false,
+        aborted: 'insufficient_size',
+        yesAsk,
+        noAsk,
+        errors: [`insufficient ask size for ${pairs.toFixed(2)} pairs`],
+      };
+    }
+    return { ok: true, yesAsk, noAsk, profitPercent };
+  }
+
+  async safeCancel(orderId, label, { market } = {}) {
     try {
       await this.cancelOrder(orderId);
       this.logger.warn?.(`[executor] rolled back ${label} order ${orderId}`);
+      return { ok: true, orderId, label };
     } catch (err) {
-      this.logger.error?.(`[executor] failed to cancel ${label} order ${orderId}: ${err?.message || err}`);
+      const alreadyFilled = isAlreadyFilledError(err);
+      const msg = err?.message || String(err);
+      if (alreadyFilled) {
+        // Naked leg — operator MUST intervene.
+        this.logger.error?.(
+          `[executor] CRITICAL: ${label} order ${orderId} already filled; manual reconciliation required: ${msg}`,
+        );
+        this.onCriticalAlert?.({
+          kind: 'naked_leg',
+          message: `Naked ${label} position: order ${orderId} filled but counter-leg failed. Reconcile immediately.`,
+          context: { orderId, leg: label, marketId: market?.id, slug: market?.slug, error: msg },
+        });
+      } else {
+        this.logger.error?.(
+          `[executor] failed to cancel ${label} order ${orderId}: ${msg}`,
+        );
+      }
+      return { ok: false, orderId, label, alreadyFilled, error: msg };
     }
   }
 }
@@ -107,3 +223,5 @@ export function makeUnavailableOrderPlacer() {
     },
   };
 }
+
+export { isAlreadyFilledError };

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,10 @@ import { PolymarketClient } from './polymarket/client.js';
 import { scan } from './scanner.js';
 import { TelegramNotifier, formatSignal } from './telegram.js';
 import { ParallelExecutor, makeUnavailableOrderPlacer } from './executor.js';
+import { TtlCache } from './ttl-cache.js';
 import { logger } from './logger.js';
+
+const SEEN_TTL_MS = 60 * 60 * 1000; // 1 hour — see issue #3 fix #3.
 
 async function runOnce({ client, cfg, telegram, executor, seen }) {
   const markets = await client.fetchActiveMarkets();
@@ -26,13 +29,8 @@ async function runOnce({ client, cfg, telegram, executor, seen }) {
       sum: signal.sum,
     });
 
-    if (telegram.enabled) {
-      try {
-        await telegram.send(msg);
-      } catch (err) {
-        logger.error('telegram send failed', err?.message || err);
-      }
-    }
+    // Fire-and-forget: never let Telegram lag block the scan loop.
+    telegram.enqueue(msg);
 
     if (cfg.mode === 'auto' && executor) {
       try {
@@ -42,18 +40,19 @@ async function runOnce({ client, cfg, telegram, executor, seen }) {
         });
         if (result.ok) {
           logger.info('executed pair', result);
-          if (telegram.enabled) {
-            await telegram.send(
-              `✅ Executed pair for <code>${signal.market.slug || signal.market.id}</code>\nYES order: ${result.yesOrderId}\nNO order: ${result.noOrderId}`,
-            ).catch(() => {});
-          }
+          telegram.enqueue(
+            `✅ Executed pair for <code>${signal.market.slug || signal.market.id}</code>\nYES order: ${result.yesOrderId}\nNO order: ${result.noOrderId}`,
+          );
+        } else if (result.aborted) {
+          logger.warn('execution aborted before placement', result);
+          telegram.enqueue(
+            `⚠️ Skipped <code>${signal.market.slug || signal.market.id}</code>: ${result.aborted} (${(result.errors || []).join('; ')})`,
+          );
         } else {
           logger.error('execution failed, rolled back', result.errors);
-          if (telegram.enabled) {
-            await telegram.send(
-              `❌ Execution failed for <code>${signal.market.slug || signal.market.id}</code>:\n${(result.errors || []).join('\n')}`,
-            ).catch(() => {});
-          }
+          telegram.enqueue(
+            `❌ Execution failed for <code>${signal.market.slug || signal.market.id}</code>:\n${(result.errors || []).join('\n')}`,
+          );
         }
       } catch (err) {
         logger.error('executor threw', err?.message || err);
@@ -76,7 +75,11 @@ async function main() {
     telegram: cfg.telegram.botToken ? 'enabled' : 'disabled',
   });
 
-  const client = new PolymarketClient({ gammaUrl: cfg.polymarket.gammaUrl });
+  const client = new PolymarketClient({
+    gammaUrl: cfg.polymarket.gammaUrl,
+    clobUrl: cfg.polymarket.clobUrl,
+    logger,
+  });
   const telegram = new TelegramNotifier({
     botToken: cfg.telegram.botToken,
     chatId: cfg.telegram.chatId,
@@ -89,12 +92,19 @@ async function main() {
     executor = new ParallelExecutor({
       placeOrder: placer.placeOrder,
       cancelOrder: placer.cancelOrder,
+      fetchOrderBook: (tokenId) => client.fetchOrderBook(tokenId),
+      feePercent: cfg.feePercent,
+      minProfitPercent: cfg.minProfitPercent,
+      onCriticalAlert: (alert) => {
+        logger.error('CRITICAL ALERT', alert);
+        telegram.enqueue(`🚨 <b>CRITICAL</b>\n${escape(alert.message)}`);
+      },
       logger,
     });
     logger.warn('auto mode: using placeholder order placer. Install @polymarket/clob-client and wire it in src/index.js before trading real funds.');
   }
 
-  const seen = new Set();
+  const seen = new TtlCache({ ttlMs: SEEN_TTL_MS });
   let stopping = false;
   const shutdown = (sig) => {
     logger.info(`received ${sig}, stopping...`);
@@ -109,11 +119,10 @@ async function main() {
     } catch (err) {
       logger.error('scan cycle failed', err?.message || err);
     }
+    seen.prune();
     await sleep(cfg.scanIntervalSec * 1000, () => stopping);
-    // Prune seen set periodically so a resolved-then-reopened market isn't
-    // muted forever (defensive: the bot is meant to run for short bursts).
-    if (seen.size > 10_000) seen.clear();
   }
+  await telegram.drain();
 }
 
 function sleep(ms, shouldStop) {
@@ -130,7 +139,16 @@ function sleep(ms, shouldStop) {
   });
 }
 
+function escape(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 main().catch((err) => {
   logger.error('fatal', err?.stack || err);
   process.exit(1);
 });
+
+export { runOnce };

--- a/src/polymarket/client.js
+++ b/src/polymarket/client.js
@@ -1,17 +1,42 @@
-// Client for the public Polymarket Gamma API.
+// Client for the public Polymarket Gamma + CLOB APIs.
 // Docs: https://docs.polymarket.com — Gamma returns market metadata and
-// top-of-book prices suitable for a cheap periodic scan.
+// outcomePrices (mid/last); CLOB exposes the real top-of-book.
+
+import { retry, HttpError } from '../retry.js';
 
 export class PolymarketClient {
-  constructor({ gammaUrl = 'https://gamma-api.polymarket.com', fetchImpl = globalThis.fetch } = {}) {
+  constructor({
+    gammaUrl = 'https://gamma-api.polymarket.com',
+    clobUrl = 'https://clob.polymarket.com',
+    fetchImpl = globalThis.fetch,
+    retryOptions,
+    logger,
+  } = {}) {
     if (!fetchImpl) {
       throw new Error('fetch is not available; pass fetchImpl or run on Node >= 18');
     }
     this.gammaUrl = gammaUrl.replace(/\/$/, '');
+    this.clobUrl = clobUrl.replace(/\/$/, '');
     this.fetch = fetchImpl;
+    this.retryOptions = retryOptions;
+    this.logger = logger;
   }
 
-  async fetchActiveMarkets({ limit = 500, offset = 0 } = {}) {
+  // Pages through `/markets` until the API returns fewer than `pageSize`
+  // records, so the scanner sees every active market (Gamma caps each page
+  // at a few hundred rows). `maxPages` is a safety cap.
+  async fetchActiveMarkets({ pageSize = 500, maxPages = 20 } = {}) {
+    const all = [];
+    for (let page = 0; page < maxPages; page += 1) {
+      const offset = page * pageSize;
+      const batch = await this.#fetchMarketsPage({ limit: pageSize, offset });
+      all.push(...batch);
+      if (batch.length < pageSize) break;
+    }
+    return all;
+  }
+
+  async #fetchMarketsPage({ limit, offset }) {
     const params = new URLSearchParams({
       active: 'true',
       closed: 'false',
@@ -20,12 +45,39 @@ export class PolymarketClient {
       offset: String(offset),
     });
     const url = `${this.gammaUrl}/markets?${params.toString()}`;
-    const res = await this.fetch(url, { headers: { accept: 'application/json' } });
-    if (!res.ok) {
-      throw new Error(`Gamma /markets failed: ${res.status} ${res.statusText}`);
-    }
-    const data = await res.json();
+    const data = await this.#getJson(url, 'Gamma /markets');
     return Array.isArray(data) ? data.map(normalizeMarket) : [];
+  }
+
+  // Real top-of-book ask/bid for a CLOB token. `outcomePrices` from Gamma is
+  // a mid/last-trade and overstates how much fills are actually available.
+  async fetchOrderBook(tokenId) {
+    if (!tokenId) throw new Error('fetchOrderBook requires tokenId');
+    const url = `${this.clobUrl}/book?token_id=${encodeURIComponent(tokenId)}`;
+    const raw = await this.#getJson(url, 'CLOB /book');
+    return parseOrderBook(raw);
+  }
+
+  async #getJson(url, label) {
+    return retry(
+      async () => {
+        const res = await this.fetch(url, { headers: { accept: 'application/json' } });
+        if (!res.ok) {
+          const body = await safeText(res);
+          throw new HttpError(`${label} failed: ${res.status} ${res.statusText}`, {
+            status: res.status,
+            body,
+          });
+        }
+        return res.json();
+      },
+      {
+        ...this.retryOptions,
+        onRetry: (err, attempt, delay) => {
+          this.logger?.warn?.(`[polymarket] retrying ${label} (attempt ${attempt}, in ${delay}ms): ${err?.message || err}`);
+        },
+      },
+    );
   }
 }
 
@@ -61,6 +113,33 @@ export function normalizeMarket(raw) {
   };
 }
 
+// CLOB /book returns { asks: [{price, size}], bids: [{price, size}] }.
+// Asks are returned sorted ascending by price; the lowest is the top-of-book.
+export function parseOrderBook(raw) {
+  const asks = normalizeLevels(raw?.asks).sort((a, b) => a.price - b.price);
+  const bids = normalizeLevels(raw?.bids).sort((a, b) => b.price - a.price);
+  return {
+    asks,
+    bids,
+    bestAsk: asks[0] || null,
+    bestBid: bids[0] || null,
+  };
+}
+
+function normalizeLevels(levels) {
+  if (!Array.isArray(levels)) return [];
+  const out = [];
+  for (const lvl of levels) {
+    if (!lvl) continue;
+    const price = Number(lvl.price ?? lvl[0]);
+    const size = Number(lvl.size ?? lvl.amount ?? lvl[1]);
+    if (Number.isFinite(price) && price > 0 && price < 1 && Number.isFinite(size) && size > 0) {
+      out.push({ price, size });
+    }
+  }
+  return out;
+}
+
 function parseJsonArray(value) {
   if (Array.isArray(value)) return value;
   if (typeof value !== 'string' || value === '') return [];
@@ -76,4 +155,8 @@ function toNumber(value) {
   if (value === undefined || value === null || value === '') return 0;
   const n = Number(value);
   return Number.isFinite(n) ? n : 0;
+}
+
+async function safeText(res) {
+  try { return await res.text(); } catch { return ''; }
 }

--- a/src/retry.js
+++ b/src/retry.js
@@ -1,0 +1,58 @@
+// Exponential backoff with jitter for transient HTTP failures (network errors,
+// 5xx, 429). Used by Gamma fetches and Telegram sends so a brief outage or
+// rate-limit doesn't drop arb signals on the floor.
+
+const DEFAULT_RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+export async function retry(fn, opts = {}) {
+  const {
+    retries = 4,
+    baseMs = 250,
+    maxMs = 4000,
+    jitter = 0.5,
+    isRetryable = defaultIsRetryable,
+    onRetry,
+    sleep = defaultSleep,
+  } = opts;
+
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      attempt += 1;
+      if (attempt > retries || !isRetryable(err)) throw err;
+      const delay = backoffDelay({ attempt, baseMs, maxMs, jitter });
+      onRetry?.(err, attempt, delay);
+      await sleep(delay);
+    }
+  }
+}
+
+export function backoffDelay({ attempt, baseMs, maxMs, jitter }) {
+  const exp = Math.min(maxMs, baseMs * 2 ** (attempt - 1));
+  const j = 1 + (Math.random() * 2 - 1) * jitter;
+  return Math.max(0, Math.round(exp * j));
+}
+
+export function defaultIsRetryable(err) {
+  if (!err) return false;
+  if (err.name === 'AbortError') return false;
+  if (typeof err.status === 'number') return DEFAULT_RETRYABLE_STATUS.has(err.status);
+  if (err.code === 'ECONNRESET' || err.code === 'ETIMEDOUT' || err.code === 'EAI_AGAIN') return true;
+  // fetch failures surface as TypeError('fetch failed') in Node 20.
+  return err.name === 'TypeError' || err.name === 'FetchError';
+}
+
+export class HttpError extends Error {
+  constructor(message, { status, body } = {}) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms > 0 ? ms : 0));
+}

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1,9 +1,21 @@
+import { retry, HttpError } from './retry.js';
+
 export class TelegramNotifier {
-  constructor({ botToken, chatId, fetchImpl = globalThis.fetch, logger = console } = {}) {
+  constructor({
+    botToken,
+    chatId,
+    fetchImpl = globalThis.fetch,
+    logger = console,
+    retryOptions,
+    sendTimeoutMs = 8000,
+  } = {}) {
     this.botToken = botToken;
     this.chatId = chatId;
     this.fetch = fetchImpl;
     this.logger = logger;
+    this.retryOptions = retryOptions;
+    this.sendTimeoutMs = sendTimeoutMs;
+    this.queue = new TelegramQueue({ logger });
   }
 
   get enabled() {
@@ -15,22 +27,86 @@ export class TelegramNotifier {
       this.logger.warn?.('[telegram] disabled (missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID)');
       return { skipped: true };
     }
-    const url = `https://api.telegram.org/bot${this.botToken}/sendMessage`;
-    const res = await this.fetch(url, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: this.chatId,
-        text,
-        parse_mode: 'HTML',
-        disable_web_page_preview: true,
-      }),
-    });
-    if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new Error(`Telegram sendMessage failed: ${res.status} ${body}`);
+    return retry(
+      () => this.#sendOnce(text),
+      {
+        ...this.retryOptions,
+        onRetry: (err, attempt, delay) => {
+          this.logger.warn?.(`[telegram] retrying send (attempt ${attempt}, in ${delay}ms): ${err?.message || err}`);
+        },
+      },
+    );
+  }
+
+  // Fire-and-forget: enqueue the message, return immediately so the scan
+  // loop never blocks on Telegram lag. Failures are logged, not thrown.
+  enqueue(text) {
+    if (!this.enabled) {
+      this.logger.warn?.('[telegram] disabled (missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID)');
+      return;
     }
-    return res.json();
+    this.queue.push(() => this.send(text));
+  }
+
+  async drain() {
+    return this.queue.drain();
+  }
+
+  async #sendOnce(text) {
+    const url = `https://api.telegram.org/bot${this.botToken}/sendMessage`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.sendTimeoutMs);
+    try {
+      const res = await this.fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          chat_id: this.chatId,
+          text,
+          parse_mode: 'HTML',
+          disable_web_page_preview: true,
+        }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new HttpError(`Telegram sendMessage failed: ${res.status} ${body}`, {
+          status: res.status,
+          body,
+        });
+      }
+      return res.json();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// Sequential async queue so concurrent enqueues don't fan out hundreds of
+// in-flight Telegram requests. Each task is awaited in order; failures are
+// logged via the supplied logger so callers don't have to try/catch.
+export class TelegramQueue {
+  constructor({ logger = console } = {}) {
+    this.logger = logger;
+    this.tail = Promise.resolve();
+    this.pending = 0;
+  }
+
+  push(taskFn) {
+    this.pending += 1;
+    this.tail = this.tail
+      .then(() => taskFn())
+      .catch((err) => {
+        this.logger.error?.(`[telegram] queued send failed: ${err?.message || err}`);
+      })
+      .finally(() => {
+        this.pending -= 1;
+      });
+    return this.tail;
+  }
+
+  async drain() {
+    return this.tail;
   }
 }
 

--- a/src/ttl-cache.js
+++ b/src/ttl-cache.js
@@ -1,0 +1,53 @@
+// Bounded TTL cache backed by a Map. Used by the scan loop to dedupe
+// already-alerted opportunities without muting a market forever (a paginated
+// API hiccup can briefly drop a market from the listing — when it comes back
+// with a fresh window we want to react again, not silently skip it).
+
+export class TtlCache {
+  constructor({ ttlMs = 60 * 60 * 1000, maxSize = 10_000, now = Date.now } = {}) {
+    this.ttlMs = ttlMs;
+    this.maxSize = maxSize;
+    this.now = now;
+    this.map = new Map();
+  }
+
+  has(key) {
+    const entry = this.map.get(key);
+    if (entry === undefined) return false;
+    if (this.#expired(entry)) {
+      this.map.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  add(key) {
+    // Re-insert to keep insertion-order roughly aligned with recency for
+    // the maxSize trim path below.
+    if (this.map.has(key)) this.map.delete(key);
+    this.map.set(key, this.now());
+    if (this.map.size > this.maxSize) {
+      const firstKey = this.map.keys().next().value;
+      if (firstKey !== undefined) this.map.delete(firstKey);
+    }
+  }
+
+  prune() {
+    let removed = 0;
+    for (const [key, ts] of this.map) {
+      if (this.#expired(ts)) {
+        this.map.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  get size() {
+    return this.map.size;
+  }
+
+  #expired(ts) {
+    return this.now() - ts >= this.ttlMs;
+  }
+}

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -1,11 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { ParallelExecutor } from '../src/executor.js';
+import { ParallelExecutor, isAlreadyFilledError } from '../src/executor.js';
 
 const silentLogger = { warn: () => {}, error: () => {}, info: () => {} };
 
 function makeMarket(overrides = {}) {
   return {
+    id: 'm1',
+    slug: 'some-market',
     yes: { price: 0.45, tokenId: 'yes-token' },
     no: { price: 0.5, tokenId: 'no-token' },
     ...overrides,
@@ -96,4 +98,121 @@ test('refuses when token ids are missing', async () => {
     }),
     /token ids/,
   );
+});
+
+test('isAlreadyFilledError detects common phrasings', () => {
+  assert.equal(isAlreadyFilledError(new Error('Order is already filled')), true);
+  assert.equal(isAlreadyFilledError(new Error('order already_matched on-chain')), true);
+  assert.equal(isAlreadyFilledError(new Error('order is complete')), true);
+  assert.equal(isAlreadyFilledError(new Error('Cannot cancel: not cancellable')), true);
+  assert.equal(isAlreadyFilledError(new Error('connection refused')), false);
+  const tagged = new Error('whatever');
+  tagged.alreadyFilled = true;
+  assert.equal(isAlreadyFilledError(tagged), true);
+});
+
+test('critical alert fires when cancel fails because leg is already filled', async () => {
+  const alerts = [];
+  const executor = new ParallelExecutor({
+    placeOrder: async ({ tokenId }) => {
+      if (tokenId === 'no-token') throw new Error('no leg rejected');
+      return { id: 'yes-order-1' };
+    },
+    cancelOrder: async () => {
+      throw new Error('Order is already filled');
+    },
+    onCriticalAlert: (a) => alerts.push(a),
+    logger: silentLogger,
+  });
+
+  const result = await executor.executeArbitrage({ market: makeMarket(), maxBetUsdc: 10 });
+  assert.equal(result.ok, false);
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].kind, 'naked_leg');
+  assert.match(alerts[0].message, /Naked YES position/);
+  assert.equal(result.naked.length, 1);
+  assert.equal(result.naked[0].label, 'YES');
+  assert.equal(result.naked[0].alreadyFilled, true);
+});
+
+test('critical alert does NOT fire when cancel fails for transient network reasons', async () => {
+  const alerts = [];
+  const executor = new ParallelExecutor({
+    placeOrder: async ({ tokenId }) => {
+      if (tokenId === 'no-token') throw new Error('no leg rejected');
+      return { id: 'yes-order-1' };
+    },
+    cancelOrder: async () => {
+      throw new Error('connection refused');
+    },
+    onCriticalAlert: (a) => alerts.push(a),
+    logger: silentLogger,
+  });
+
+  const result = await executor.executeArbitrage({ market: makeMarket(), maxBetUsdc: 10 });
+  assert.equal(result.ok, false);
+  assert.equal(alerts.length, 0);
+  assert.equal(result.naked.length, 0);
+});
+
+test('aborts when real top-of-book ask kills the arb', async () => {
+  const placed = [];
+  const executor = new ParallelExecutor({
+    placeOrder: async (a) => { placed.push(a); return { id: 'x' }; },
+    cancelOrder: async () => {},
+    fetchOrderBook: async (tokenId) => {
+      // Real asks much higher than mid-quote: arb is gone.
+      const price = tokenId === 'yes-token' ? 0.55 : 0.55;
+      return { bestAsk: { price, size: 1000 }, bestBid: null };
+    },
+    feePercent: 2,
+    minProfitPercent: 3,
+    logger: silentLogger,
+  });
+
+  const result = await executor.executeArbitrage({ market: makeMarket(), maxBetUsdc: 10 });
+  assert.equal(result.ok, false);
+  assert.equal(result.aborted, 'real_ask_too_high');
+  assert.equal(placed.length, 0);
+});
+
+test('aborts when real top-of-book has insufficient size', async () => {
+  const placed = [];
+  const executor = new ParallelExecutor({
+    placeOrder: async (a) => { placed.push(a); return { id: 'x' }; },
+    cancelOrder: async () => {},
+    fetchOrderBook: async () => ({
+      bestAsk: { price: 0.45, size: 0.1 }, // not enough size
+      bestBid: null,
+    }),
+    feePercent: 2,
+    minProfitPercent: 1,
+    logger: silentLogger,
+  });
+
+  const result = await executor.executeArbitrage({ market: makeMarket(), maxBetUsdc: 10 });
+  assert.equal(result.ok, false);
+  assert.equal(result.aborted, 'insufficient_size');
+  assert.equal(placed.length, 0);
+});
+
+test('proceeds and uses real ask when book confirms arb', async () => {
+  const placed = [];
+  const executor = new ParallelExecutor({
+    placeOrder: async (a) => { placed.push(a); return { id: `o-${a.tokenId}` }; },
+    cancelOrder: async () => {},
+    fetchOrderBook: async (tokenId) => ({
+      bestAsk: { price: tokenId === 'yes-token' ? 0.46 : 0.51, size: 1000 },
+      bestBid: null,
+    }),
+    feePercent: 2,
+    minProfitPercent: 0.5,
+    logger: silentLogger,
+  });
+
+  const result = await executor.executeArbitrage({ market: makeMarket(), maxBetUsdc: 10 });
+  assert.equal(result.ok, true);
+  // Order was placed at the real ask, not the stale Gamma quote.
+  const yesOrder = placed.find((p) => p.tokenId === 'yes-token');
+  assert.equal(yesOrder.price, 0.46);
 });

--- a/test/polymarket-client.test.js
+++ b/test/polymarket-client.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { PolymarketClient, normalizeMarket } from '../src/polymarket/client.js';
+import { PolymarketClient, normalizeMarket, parseOrderBook } from '../src/polymarket/client.js';
 
 test('normalizeMarket parses JSON-encoded outcome arrays', () => {
   const raw = {
@@ -70,8 +70,105 @@ test('PolymarketClient fetches and normalizes markets', async () => {
   assert.equal(markets[0].yes.price, 0.4);
 });
 
-test('PolymarketClient throws on non-2xx', async () => {
-  const fetchImpl = async () => ({ ok: false, status: 502, statusText: 'Bad Gateway' });
+test('PolymarketClient pages through markets until a short page', async () => {
+  const calls = [];
+  let call = 0;
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      async json() {
+        // Return 2 full pages of size 2, then a final short page with 1 row.
+        if (call === 1) return [{ id: 'a' }, { id: 'b' }];
+        if (call === 2) return [{ id: 'c' }, { id: 'd' }];
+        return [{ id: 'e' }];
+      },
+    };
+  };
   const client = new PolymarketClient({ fetchImpl });
+  const markets = await client.fetchActiveMarkets({ pageSize: 2 });
+  assert.equal(markets.length, 5);
+  assert.equal(calls.length, 3);
+  assert.ok(calls[0].includes('offset=0'));
+  assert.ok(calls[1].includes('offset=2'));
+  assert.ok(calls[2].includes('offset=4'));
+});
+
+test('PolymarketClient retries on 429 and eventually succeeds', async () => {
+  let call = 0;
+  const fetchImpl = async () => {
+    call += 1;
+    if (call < 3) {
+      return {
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        async text() { return 'rate limited'; },
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      async json() { return []; },
+    };
+  };
+  const client = new PolymarketClient({
+    fetchImpl,
+    retryOptions: { retries: 5, baseMs: 1, maxMs: 5, jitter: 0 },
+  });
+  const markets = await client.fetchActiveMarkets({ pageSize: 10 });
+  assert.equal(markets.length, 0);
+  assert.equal(call, 3);
+});
+
+test('PolymarketClient.fetchOrderBook returns sorted top-of-book', async () => {
+  const fetchImpl = async (url) => {
+    assert.ok(url.includes('/book?token_id=tok-1'));
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      async json() {
+        return {
+          asks: [
+            { price: '0.55', size: '50' },
+            { price: '0.50', size: '100' },
+            { price: '0.60', size: '20' },
+          ],
+          bids: [
+            { price: '0.40', size: '70' },
+            { price: '0.45', size: '30' },
+          ],
+        };
+      },
+    };
+  };
+  const client = new PolymarketClient({ fetchImpl });
+  const book = await client.fetchOrderBook('tok-1');
+  assert.equal(book.bestAsk.price, 0.5);
+  assert.equal(book.bestAsk.size, 100);
+  assert.equal(book.bestBid.price, 0.45);
+});
+
+test('parseOrderBook tolerates empty / malformed input', () => {
+  const empty = parseOrderBook(null);
+  assert.equal(empty.bestAsk, null);
+  assert.equal(empty.bestBid, null);
+  const partial = parseOrderBook({ asks: [{ price: 'NaN', size: 5 }, { price: 0.7, size: 1 }] });
+  assert.equal(partial.bestAsk.price, 0.7);
+});
+
+test('PolymarketClient throws on non-2xx', async () => {
+  const fetchImpl = async () => ({
+    ok: false,
+    status: 502,
+    statusText: 'Bad Gateway',
+    async text() { return ''; },
+  });
+  const client = new PolymarketClient({ fetchImpl, retryOptions: { retries: 0 } });
   await assert.rejects(() => client.fetchActiveMarkets(), /502/);
 });

--- a/test/retry.test.js
+++ b/test/retry.test.js
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { retry, defaultIsRetryable, HttpError, backoffDelay } from '../src/retry.js';
+
+test('retry returns the value on first success', async () => {
+  const result = await retry(async () => 'hello', { retries: 3 });
+  assert.equal(result, 'hello');
+});
+
+test('retry retries on retryable errors and eventually succeeds', async () => {
+  let attempts = 0;
+  const out = await retry(
+    async () => {
+      attempts += 1;
+      if (attempts < 3) throw new HttpError('boom', { status: 503 });
+      return 'ok';
+    },
+    { retries: 5, baseMs: 1, maxMs: 5, jitter: 0 },
+  );
+  assert.equal(attempts, 3);
+  assert.equal(out, 'ok');
+});
+
+test('retry surfaces non-retryable errors immediately', async () => {
+  let attempts = 0;
+  await assert.rejects(
+    retry(
+      async () => {
+        attempts += 1;
+        throw new HttpError('client error', { status: 400 });
+      },
+      { retries: 5, baseMs: 1, maxMs: 5, jitter: 0 },
+    ),
+    /client error/,
+  );
+  assert.equal(attempts, 1);
+});
+
+test('retry gives up after configured retries', async () => {
+  let attempts = 0;
+  await assert.rejects(
+    retry(
+      async () => {
+        attempts += 1;
+        throw new HttpError('boom', { status: 502 });
+      },
+      { retries: 2, baseMs: 1, maxMs: 5, jitter: 0 },
+    ),
+    /boom/,
+  );
+  assert.equal(attempts, 3); // initial + 2 retries
+});
+
+test('defaultIsRetryable classifies common cases', () => {
+  assert.equal(defaultIsRetryable(new HttpError('x', { status: 429 })), true);
+  assert.equal(defaultIsRetryable(new HttpError('x', { status: 500 })), true);
+  assert.equal(defaultIsRetryable(new HttpError('x', { status: 404 })), false);
+  const network = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+  assert.equal(defaultIsRetryable(network), true);
+});
+
+test('backoffDelay grows roughly exponentially within bounds', () => {
+  const a = backoffDelay({ attempt: 1, baseMs: 100, maxMs: 10_000, jitter: 0 });
+  const b = backoffDelay({ attempt: 2, baseMs: 100, maxMs: 10_000, jitter: 0 });
+  const c = backoffDelay({ attempt: 3, baseMs: 100, maxMs: 10_000, jitter: 0 });
+  assert.equal(a, 100);
+  assert.equal(b, 200);
+  assert.equal(c, 400);
+});

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { TelegramNotifier, formatSignal } from '../src/telegram.js';
+import { TelegramNotifier, TelegramQueue, formatSignal } from '../src/telegram.js';
 
 test('TelegramNotifier reports disabled without creds', async () => {
   const notifier = new TelegramNotifier({ logger: { warn: () => {} } });
@@ -26,6 +26,68 @@ test('TelegramNotifier posts to bot API', async () => {
   assert.ok(capturedUrl.endsWith('/botabc/sendMessage'));
   assert.equal(capturedBody.chat_id, '123');
   assert.equal(capturedBody.text, 'hello');
+});
+
+test('TelegramNotifier retries on 429 then succeeds', async () => {
+  let call = 0;
+  const fetchImpl = async () => {
+    call += 1;
+    if (call < 3) {
+      return {
+        ok: false,
+        status: 429,
+        async text() { return 'rate limit'; },
+        async json() { return {}; },
+      };
+    }
+    return { ok: true, async json() { return { ok: true }; } };
+  };
+  const notifier = new TelegramNotifier({
+    botToken: 'tok',
+    chatId: '1',
+    fetchImpl,
+    logger: { warn: () => {}, error: () => {} },
+    retryOptions: { retries: 5, baseMs: 1, maxMs: 5, jitter: 0 },
+  });
+  await notifier.send('hello');
+  assert.equal(call, 3);
+});
+
+test('TelegramNotifier.enqueue returns immediately and does not throw on failure', async () => {
+  const errors = [];
+  const fetchImpl = async () => { throw new Error('nope'); };
+  const notifier = new TelegramNotifier({
+    botToken: 't',
+    chatId: 'c',
+    fetchImpl,
+    logger: { warn: () => {}, error: (m) => errors.push(m) },
+    retryOptions: { retries: 0 },
+  });
+  const start = Date.now();
+  notifier.enqueue('msg-1');
+  notifier.enqueue('msg-2');
+  // enqueue must be sync — it returns void. Confirm by elapsed time:
+  assert.ok(Date.now() - start < 50);
+  await notifier.drain();
+  assert.equal(errors.length, 2);
+});
+
+test('TelegramQueue serializes pushes', async () => {
+  const order = [];
+  const queue = new TelegramQueue({ logger: { error: () => {} } });
+  let resolveFirst;
+  const first = new Promise((r) => { resolveFirst = r; });
+  queue.push(async () => {
+    order.push('first-start');
+    await first;
+    order.push('first-end');
+  });
+  queue.push(async () => {
+    order.push('second');
+  });
+  resolveFirst();
+  await queue.drain();
+  assert.deepEqual(order, ['first-start', 'first-end', 'second']);
 });
 
 test('formatSignal includes key fields', () => {

--- a/test/ttl-cache.test.js
+++ b/test/ttl-cache.test.js
@@ -1,0 +1,71 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TtlCache } from '../src/ttl-cache.js';
+
+test('add+has tracks recent keys', () => {
+  let now = 1_000;
+  const cache = new TtlCache({ ttlMs: 100, now: () => now });
+  cache.add('a');
+  assert.equal(cache.has('a'), true);
+  assert.equal(cache.has('b'), false);
+});
+
+test('expired keys are dropped on read', () => {
+  let now = 0;
+  const cache = new TtlCache({ ttlMs: 100, now: () => now });
+  cache.add('a');
+  now = 99;
+  assert.equal(cache.has('a'), true);
+  now = 200;
+  assert.equal(cache.has('a'), false);
+  assert.equal(cache.size, 0);
+});
+
+test('prune removes only expired entries', () => {
+  let now = 0;
+  const cache = new TtlCache({ ttlMs: 100, now: () => now });
+  cache.add('a');
+  now = 50;
+  cache.add('b');
+  now = 120;
+  const removed = cache.prune();
+  assert.equal(removed, 1);
+  assert.equal(cache.has('b'), true);
+  assert.equal(cache.has('a'), false);
+});
+
+test('add re-bumps recency for an existing key', () => {
+  let now = 0;
+  const cache = new TtlCache({ ttlMs: 100, now: () => now });
+  cache.add('a');
+  now = 80;
+  cache.add('a'); // re-add resets timestamp
+  now = 150;
+  // 70ms after re-add — still fresh
+  assert.equal(cache.has('a'), true);
+});
+
+test('maxSize trims oldest entry', () => {
+  let now = 0;
+  const cache = new TtlCache({ ttlMs: 1000, maxSize: 2, now: () => now });
+  cache.add('a');
+  now = 1;
+  cache.add('b');
+  now = 2;
+  cache.add('c');
+  assert.equal(cache.size, 2);
+  assert.equal(cache.has('a'), false);
+  assert.equal(cache.has('b'), true);
+  assert.equal(cache.has('c'), true);
+});
+
+test('reopened market is re-emitted after TTL expiry', () => {
+  let now = 0;
+  const cache = new TtlCache({ ttlMs: 60 * 60 * 1000, now: () => now });
+  cache.add('cond-1');
+  // Same scan iteration: filtered out as duplicate.
+  assert.equal(cache.has('cond-1'), true);
+  // 2 hours later: market reappears in API; cache must allow re-alert.
+  now = 2 * 60 * 60 * 1000;
+  assert.equal(cache.has('cond-1'), false);
+});


### PR DESCRIPTION
Fixes maksmoroz91/poly#3.

Addresses all six issues raised in the review of the original arbitrage bot — three critical (auto-mode could lose money or silently leave naked positions) and three important (scan loop could miss or drop signals).

## 🔴 Critical fixes

### 1. Real top-of-book ask is re-checked before placing orders
Gamma's `outcomePrices` is a midpoint/last-trade quote, so an arb that looks profitable on paper can vanish at the real ask. In auto mode the executor now pulls the real top-of-book from `CLOB /book?token_id=...` for both legs and re-validates `(yesAsk + noAsk)` against `MIN_PROFIT_PERCENT` and the requested size **before** any order is placed. If the real spread is gone the trade is aborted with `aborted: 'real_ask_too_high'` (or `'insufficient_size'`) and no capital is deployed.

- `src/executor.js`: `recheckTopOfBook()` + `fetchOrderBook` injection
- `src/polymarket/client.js`: `fetchOrderBook(tokenId)` + `parseOrderBook()`
- `src/index.js`: wires `client.fetchOrderBook` + `feePercent` + `minProfitPercent` into the executor in auto mode

### 2. Rollback distinguishes `already_filled` from network failures
Previously `safeCancel` swallowed every cancel error, so an `already_filled` response (= the leg actually executed) looked the same as a transient timeout — leaving the operator naked on one side without warning. Now `isAlreadyFilledError()` matches several common phrasings (and respects an explicit `err.alreadyFilled` flag); a positive match raises `onCriticalAlert({ kind: 'naked_leg', ... })` which `index.js` forwards as a 🚨 Telegram message.

### 3. `seen` set replaced with a 1-hour TTL cache
The old `seen.size > 10_000` clear meant a market that briefly disappeared from `/markets` (pagination, lag, archive blip) and reappeared with a fresh window would be silently muted. New `TtlCache` evicts entries after 1h (configurable), with `prune()` called every iteration and a `maxSize` safety cap.

## 🟡 Important fixes

### 4. `/markets` is paginated until a short page
`fetchActiveMarkets()` now loops `offset += pageSize` until the API returns fewer than `pageSize` rows (with a `maxPages` safety cap), so installs with > 500 active markets see all of them.

### 5. Exponential backoff + jitter for HTTP failures
New `src/retry.js` helper. Gamma `/markets`, CLOB `/book` and Telegram `sendMessage` are all wrapped — they retry on `429`, `5xx`, and transient network errors (`ECONNRESET`, `ETIMEDOUT`, fetch failures), so a brief outage no longer drops an arb signal.

### 6. Telegram dispatch is queued, never blocks the scan loop
`TelegramNotifier.enqueue()` is fire-and-forget — it returns synchronously and pushes onto a serialized `TelegramQueue`. Sends use an `AbortController` timeout (default 8s). The main loop calls `enqueue` everywhere instead of `await telegram.send(...)`, so a slow Bot API can no longer freeze the scanner.

## Files

| Module | Change |
| --- | --- |
| `src/retry.js` *(new)* | exponential backoff + jitter helper, `HttpError` |
| `src/ttl-cache.js` *(new)* | bounded TTL cache for signal dedupe |
| `src/polymarket/client.js` | pagination loop, `fetchOrderBook`, retry-wrapped HTTP |
| `src/executor.js` | real-ask re-check, `naked_leg` critical alert, structured rollback result |
| `src/telegram.js` | retry, `enqueue()` + `TelegramQueue`, send timeout |
| `src/index.js` | wires it all together (TTL cache, fetchOrderBook, critical alerts, fire-and-forget Telegram) |
| `README.md` | updated Safety section + project layout |

## Tests

```
$ npm test
# tests 62
# pass 62
# fail 0
```

25 new tests covering each fix:

- **Real-ask re-check**: aborts when CLOB ask kills profit, aborts on insufficient size, places at real ask when book confirms (`test/executor.test.js`).
- **`already_filled` detection**: `isAlreadyFilledError` recognizes common phrasings; `naked_leg` alert fires only when a fill is detected, not on transient errors (`test/executor.test.js`).
- **Pagination**: client pages through 3 batches and stops on a short page (`test/polymarket-client.test.js`).
- **Retry**: succeeds after 429s, surfaces non-retryable errors, gives up after configured retries; `defaultIsRetryable` classification; `backoffDelay` exponential growth (`test/retry.test.js`, `test/polymarket-client.test.js`, `test/telegram.test.js`).
- **TTL cache**: expiry, prune, recency bump, `maxSize` trim, and the reopened-market scenario from issue #3 (`test/ttl-cache.test.js`).
- **Telegram queue**: `enqueue` returns immediately and never throws on failure; `TelegramQueue` serializes pushes (`test/telegram.test.js`).

## Reproducibility

The "naked leg" and "real-ask kills arb" scenarios are both demonstrated as failing-then-passing tests in `test/executor.test.js` — they fail against the pre-fix executor (which has no `fetchOrderBook` hook and no `onCriticalAlert`) and pass against the new one.