### PR TITLE
fix: scan CLOB order book for real arbitrage signals

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-22T13:09:04.642Z for PR creation at branch issue-5-fb31a567efae for issue https://github.com/maksmoroz91/poly/issues/5

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-22T13:09:04.642Z for PR creation at branch issue-5-fb31a567efae for issue https://github.com/maksmoroz91/poly/issues/5

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,13 @@ async function runOnce({ client, cfg, telegram, executor, seen }) {
   const markets = await client.fetchActiveMarkets();
   logger.info(`fetched ${markets.length} markets`);
 
-  const signals = scan(markets, cfg);
+  const signals = await scan(
+    markets,
+    cfg,
+    Date.now(),
+    (tokenId) => client.fetchOrderBook(tokenId),
+    logger,
+  );
   logger.info(`found ${signals.length} arbitrage signals`);
 
   for (const signal of signals) {

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -1,9 +1,16 @@
 import { categorize, priorityOf } from './categorize.js';
+import { logger as defaultLogger } from './logger.js';
 
-// A market is "ready" when both YES and NO have sensible top-of-book asks.
-// Gamma's outcomePrices field is a midpoint/last trade on many rows, so in
-// auto mode the executor re-checks the real ask from the order book before
-// firing a trade. The scanner uses the cheaper Gamma snapshot for filtering.
+// Gamma's outcomePrices are YES/NO probabilities that sum to $1.00 by
+// definition, so arbitrage math on them can never flag a signal. The real
+// spread lives in the CLOB order book — so when a fetchOrderBook fn is
+// supplied the scanner pulls the top-of-book ask for each candidate and runs
+// the arb math on real prices. Without it we fall back to Gamma prices purely
+// for backwards compatibility (existing callers / tests).
+
+// Soft warning cap: more candidates than this in a single cycle means the
+// filters are too loose and the bot risks hammering CLOB /book.
+const CLOB_WARN_THRESHOLD = 500;
 
 export function daysUntil(endDateIso, now = Date.now()) {
   if (!endDateIso) return Infinity;
@@ -42,13 +49,55 @@ function isFiniteAsk(p) {
   return Number.isFinite(p) && p > 0 && p < 1;
 }
 
-export function scan(markets, cfg, now = Date.now()) {
-  const signals = [];
+export async function scan(markets, cfg, now = Date.now(), fetchOrderBook = null, log = defaultLogger) {
+  const candidates = [];
   for (const market of markets) {
     if (!passesFilters(market, cfg, now)) continue;
+    candidates.push(market);
+  }
+
+  log?.info?.(`scanner: ${candidates.length}/${markets.length} markets passed filters`);
+  if (fetchOrderBook && candidates.length > CLOB_WARN_THRESHOLD) {
+    log?.warn?.(
+      `scanner: ${candidates.length} candidates exceeds CLOB warn threshold ${CLOB_WARN_THRESHOLD}; tighten filters to avoid rate limits`,
+    );
+  }
+
+  const signals = [];
+  let clobChecked = 0;
+  let clobErrors = 0;
+
+  for (const market of candidates) {
+    let yesAsk = market.yes.price;
+    let noAsk = market.no.price;
+
+    if (fetchOrderBook) {
+      try {
+        const [yesBook, noBook] = await Promise.all([
+          fetchOrderBook(market.yes.tokenId),
+          fetchOrderBook(market.no.tokenId),
+        ]);
+        const yesLevel = yesBook?.bestAsk;
+        const noLevel = noBook?.bestAsk;
+        if (!isFiniteAsk(yesLevel?.price) || !isFiniteAsk(noLevel?.price)) {
+          // No real ask on one side means no tradeable arb; skip quietly.
+          continue;
+        }
+        yesAsk = yesLevel.price;
+        noAsk = noLevel.price;
+        clobChecked += 1;
+      } catch (err) {
+        clobErrors += 1;
+        log?.warn?.(
+          `scanner: CLOB book fetch failed for ${market.slug || market.id}: ${err?.message || err}`,
+        );
+        continue;
+      }
+    }
+
     const arb = computeArbitrage({
-      yesAsk: market.yes.price,
-      noAsk: market.no.price,
+      yesAsk,
+      noAsk,
       feePercent: cfg.feePercent,
     });
     if (!arb.isOpportunity) continue;
@@ -59,9 +108,18 @@ export function scan(markets, cfg, now = Date.now()) {
       category,
       priority: priorityOf(category),
       daysToClose: daysUntil(market.endDateIso, now),
+      yesAsk,
+      noAsk,
       ...arb,
     });
   }
+
+  if (fetchOrderBook) {
+    log?.info?.(
+      `scanner: CLOB-checked ${clobChecked}/${candidates.length} candidates (${clobErrors} errors)`,
+    );
+  }
+
   // Highest priority first (esports), then best profit.
   signals.sort((a, b) => a.priority - b.priority || b.profitPercent - a.profitPercent);
   return signals;

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -11,6 +11,8 @@ const baseCfg = {
   feePercent: 2,
 };
 
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
 function market(overrides = {}) {
   return {
     id: '1',
@@ -64,7 +66,7 @@ test('passesFilters rejects missing legs', () => {
   assert.equal(passesFilters(market({ no: null }), baseCfg), false);
 });
 
-test('scan returns signals sorted by category priority', () => {
+test('scan returns signals sorted by category priority', async () => {
   const esports = market({ id: 'e', conditionId: 'ce', question: 'CS2 major winner' });
   const crypto = market({
     id: 'c',
@@ -85,18 +87,78 @@ test('scan returns signals sorted by category priority', () => {
     no: { price: 0.5, tokenId: 'n3' },
   });
 
-  const signals = scan([crypto, politics, esports], baseCfg);
+  const signals = await scan([crypto, politics, esports], baseCfg, Date.now(), null, silentLogger);
   assert.equal(signals.length, 3);
   assert.equal(signals[0].category, 'esports');
   assert.equal(signals[1].category, 'politics');
   assert.equal(signals[2].category, 'crypto');
 });
 
-test('scan drops opportunities below minProfitPercent', () => {
+test('scan drops opportunities below minProfitPercent', async () => {
   // yes+no = 0.97, fee 2% => threshold 0.98, profit ≈ (0.98-0.97)/0.97 ≈ 1.03%
   const m = market({ yes: { price: 0.48, tokenId: 'y' }, no: { price: 0.49, tokenId: 'n' } });
   const cfgHigh = { ...baseCfg, minProfitPercent: 10 };
-  assert.equal(scan([m], cfgHigh).length, 0);
+  assert.equal((await scan([m], cfgHigh, Date.now(), null, silentLogger)).length, 0);
   const cfgLow = { ...baseCfg, minProfitPercent: 0.5 };
-  assert.equal(scan([m], cfgLow).length, 1);
+  assert.equal((await scan([m], cfgLow, Date.now(), null, silentLogger)).length, 1);
+});
+
+test('scan with fetchOrderBook emits a signal when CLOB sum clears threshold', async () => {
+  // Gamma prices sum to 1.00 (no arb possible on them). CLOB asks are tighter.
+  const m = market({
+    yes: { price: 0.55, tokenId: 'y-clob' },
+    no: { price: 0.45, tokenId: 'n-clob' },
+  });
+  const books = {
+    'y-clob': { bestAsk: { price: 0.45, size: 100 } },
+    'n-clob': { bestAsk: { price: 0.5, size: 100 } },
+  };
+  const fetchOrderBook = async (id) => books[id];
+  const signals = await scan([m], baseCfg, Date.now(), fetchOrderBook, silentLogger);
+  assert.equal(signals.length, 1);
+  assert.equal(signals[0].yesAsk, 0.45);
+  assert.equal(signals[0].noAsk, 0.5);
+  assert.ok(signals[0].profitPercent > 0);
+});
+
+test('scan with fetchOrderBook drops markets when CLOB sum fails threshold', async () => {
+  const m = market();
+  const books = {
+    y1: { bestAsk: { price: 0.7, size: 100 } },
+    n1: { bestAsk: { price: 0.35, size: 100 } },
+  };
+  const fetchOrderBook = async (id) => books[id];
+  const signals = await scan([m], baseCfg, Date.now(), fetchOrderBook, silentLogger);
+  assert.equal(signals.length, 0);
+});
+
+test('scan skips a market when fetchOrderBook throws and continues the loop', async () => {
+  const bad = market({ id: 'bad', conditionId: 'bad', slug: 'bad', yes: { price: 0.45, tokenId: 'bad-y' }, no: { price: 0.5, tokenId: 'bad-n' } });
+  const good = market({ id: 'good', conditionId: 'good', slug: 'good', yes: { price: 0.45, tokenId: 'good-y' }, no: { price: 0.5, tokenId: 'good-n' } });
+  const books = {
+    'good-y': { bestAsk: { price: 0.45, size: 100 } },
+    'good-n': { bestAsk: { price: 0.5, size: 100 } },
+  };
+  const fetchOrderBook = async (id) => {
+    if (id.startsWith('bad')) throw new Error('boom');
+    return books[id];
+  };
+  const signals = await scan([bad, good], baseCfg, Date.now(), fetchOrderBook, silentLogger);
+  assert.equal(signals.length, 1);
+  assert.equal(signals[0].market.id, 'good');
+});
+
+test('scan falls back to Gamma prices when fetchOrderBook is not provided', async () => {
+  const m = market();
+  const signals = await scan([m], baseCfg, Date.now(), null, silentLogger);
+  assert.equal(signals.length, 1);
+  assert.equal(signals[0].yesAsk, 0.45);
+  assert.equal(signals[0].noAsk, 0.5);
+});
+
+test('scan with fetchOrderBook skips market when CLOB has no asks', async () => {
+  const m = market();
+  const fetchOrderBook = async () => ({ bestAsk: null });
+  const signals = await scan([m], baseCfg, Date.now(), fetchOrderBook, silentLogger);
+  assert.equal(signals.length, 0);
 });


### PR DESCRIPTION
## Summary

Fixes maksmoroz91/poly#5.

Gamma's `outcomePrices` are YES/NO probabilities that sum to `$1.00` by definition — the bot could never flag a signal on them. Real arbitrage lives in the CLOB order book, where `YES ask + NO ask` can drop below `$1.00`. This PR rewires the scanner so it runs arb math on real CLOB prices:

- `src/scanner.js`: `scan()` now accepts an optional `fetchOrderBook` (and a logger). After a market passes the cheap Gamma filters (liquidity / volume / closing date), the scanner pulls `bestAsk` for YES and NO in **parallel** (`Promise.all`) and runs `computeArbitrage` on those real prices. Markets whose book fetch throws or has no ask are skipped and the loop continues. The scanner logs the filter count, the checked count, and warns if candidates exceed `500` per cycle.
- `src/index.js`: passes `(tokenId) => client.fetchOrderBook(tokenId)` into `scan()` so the main loop scans real CLOB prices.
- Backwards compatible: `scan(markets, cfg)` with no `fetchOrderBook` still works against Gamma prices, so existing callers keep their behavior.
- Does not touch `computeArbitrage()`, `passesFilters()`, `daysUntil()`, `executor.js`, nor add any dependency.

## Tests

Existing scanner tests are preserved (now awaited — `scan` is async). New tests cover:

- `scan` with `fetchOrderBook` returning a CLOB sum **below** threshold → signal emitted with real YES/NO asks.
- `scan` with `fetchOrderBook` returning a CLOB sum **above** threshold → no signal.
- `scan` when `fetchOrderBook` **throws** for one market → that market is skipped, next candidate still processed.
- `scan` with no `fetchOrderBook` → Gamma-price fallback behaves exactly as before.
- `scan` when CLOB returns no `bestAsk` → market skipped quietly.

Full suite:

```
$ npm test
# tests 67
# pass 67
# fail 0
```

## Reproduction

Before: `npm run scan` would log `found 0 arbitrage signals` on every cycle because Gamma prices always sum to `1.0`. After: the scanner pulls real CLOB asks for every candidate, so signals are flagged when the real spread clears `MIN_PROFIT_PERCENT` — or the bot honestly logs no arb when the book is tight.

## Test plan

- [x] `npm test` passes locally (67/67).
- [x] Existing `scan()` callers continue to work without `fetchOrderBook`.
- [x] New code paths covered by unit tests (CLOB signal / no signal / throw / no-ask).
- [ ] Manual `npm run scan` against live Polymarket (requires network).